### PR TITLE
Beneficiary address bug fixes

### DIFF
--- a/src/EntryPoint/BeneficiariesEntryPoint.php
+++ b/src/EntryPoint/BeneficiariesEntryPoint.php
@@ -151,6 +151,7 @@ class BeneficiariesEntryPoint extends AbstractEntityEntryPoint
             'bank_account_type' => $beneficiary->getBankAccountType(),
             'beneficiary_entity_type' => $beneficiary->getBeneficiaryEntityType(),
             'beneficiary_company_name' => $beneficiary->getBeneficiaryCompanyName(),
+            'beneficiary_address' => $beneficiary->getBeneficiaryAddress(),
             'beneficiary_first_name' => $beneficiary->getBeneficiaryFirstName(),
             'beneficiary_last_name' => $beneficiary->getBeneficiaryLastName(),
             'beneficiary_city' => $beneficiary->getBeneficiaryCity(),

--- a/src/Model/Beneficiary.php
+++ b/src/Model/Beneficiary.php
@@ -116,7 +116,7 @@ class Beneficiary implements EntityInterface
      */
     private $routingCodeValue2;
     /**
-     * @var array
+     * @var string
      */
     private $beneficiaryAddress;
     /**
@@ -637,11 +637,11 @@ class Beneficiary implements EntityInterface
     }
 
     /**
-     * @param array $beneficiaryAddress
+     * @param string $beneficiaryAddress
      *
      * @return $this
      */
-    public function setBeneficiaryAddress(array $beneficiaryAddress = null)
+    public function setBeneficiaryAddress($beneficiaryAddress = null)
     {
         $this->beneficiaryAddress = $beneficiaryAddress;
         return $this;


### PR DESCRIPTION
**Bug fixes to create beneficiary with an address**
- Set beneficiary now accepting a string, rather than an array, as documented at https://developer.currencycloud.com/documentation/api-docs/beneficiaries/post-beneficiaries-create/
- 'beneficiary_address' now included in convertBeneficiaryToRequest() to ensure it gets sent to the API. All other beneficiary attributes are included here but 'beneficiary_address' was missing.
