### PR TITLE
Corrected production API URL which was missing v2/ URI

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -13,7 +13,7 @@ class Session
     const ENVIRONMENT_UAT           = 'uat';
 
     private static $urls = [
-        self::ENVIRONMENT_PRODUCTION => 'https://api.thecurrencycloud.com',
+        self::ENVIRONMENT_PRODUCTION => 'https://api.thecurrencycloud.com/v2/',
         self::ENVIRONMENT_DEMONSTRATION => 'https://devapi.thecurrencycloud.com/v2/',
         self::ENVIRONMENT_UAT => 'https://api-uat1.ccycloud.com'
     ];


### PR DESCRIPTION
**Motivation**

I used the production API Key but could get a response. I checked the source code and found it was connecting to "https://api.thecurrencycloud.com". So I tried this URL outside of the SDK and could not access the endpoints e.g.

https://api.thecurrencycloud.com/authenticate/api
{"status":"error","message":"/authenticate/api is nowhere to be found"}

So I took a guess and added the V2, e.g. https://api.thecurrencycloud.com/v2/authenticate/api, which I could authenticate against.

**Fix**

Appended "v2/" to the end of the production API URL. This matches the demonstration URI and I'm assuming that trailing slash is required.
