### PR TITLE
support unique_request_id in payments and conversions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
   "require": {
     "php": ">=5.5",
     "guzzlehttp/guzzle": "~6.1",
-    "symfony/yaml": "~2.7",
-    "symfony/event-dispatcher": "^2.7"
+    "symfony/yaml": "~3.1|~2.7",
+    "symfony/event-dispatcher": "~3.1|~2.7"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7",

--- a/src/EntryPoint/ConversionsEntryPoint.php
+++ b/src/EntryPoint/ConversionsEntryPoint.php
@@ -42,6 +42,7 @@ class ConversionsEntryPoint extends AbstractEntryPoint
                 'conversion_date' => (null === $conversionDate) ? null : $conversionDate->format(DateTime::RFC3339),
                 'client_buy_amount' => $conversion->getClientBuyAmount(),
                 'client_sell_amount' => $conversion->getClientSellAmount(),
+                'unique_request_id' => empty($conversion->getUniqueRequestId()) ? null : $conversion->getUniqueRequestId(),
                 'on_behalf_of' => $onBehalfOf
             ]
         );

--- a/src/EntryPoint/PaymentsEntryPoint.php
+++ b/src/EntryPoint/PaymentsEntryPoint.php
@@ -49,6 +49,9 @@ class PaymentsEntryPoint extends AbstractEntityEntryPoint
             'beneficiary_id' => $payment->getBeneficiaryId(),
             'conversion_id' => $payment->getConversionId()
         ];
+        if (!empty($payment->getUniqueRequestId())) {
+            $common['unique_request_id'] = $payment->getUniqueRequestId();
+        }
         if ($convertForFind) {
             return $common + [
                 'short_reference' => $payment->getShortReference(),

--- a/src/Model/Conversion.php
+++ b/src/Model/Conversion.php
@@ -123,6 +123,11 @@ class Conversion
     private $updatedAt;
 
     /**
+     * @var string
+     */
+    private $uniqueRequestId;
+
+    /**
      * @param string $buyCurrency
      * @param string $sellCurrency
      * @param string $fixedSide
@@ -657,4 +662,24 @@ class Conversion
         $this->coreRate = $coreRate;
         return $this;
     }
+
+    /**
+     * @return string
+     */
+    public function getUniqueRequestId()
+    {
+        return $this->uniqueRequestId;
+    }
+
+    /**
+     * @param string $uniqueRequestId
+     *
+     * @return $this
+     */
+    public function setUniqueRequestId($uniqueRequestId)
+    {
+        $this->uniqueRequestId = $uniqueRequestId;
+        return $this;
+    }
+
 }

--- a/src/Model/Payment.php
+++ b/src/Model/Payment.php
@@ -89,6 +89,11 @@ class Payment implements EntityInterface
     private $updatedAt;
 
     /**
+     * @var string
+     */
+    private $uniqueRequestId;
+
+    /**
      * @param string $currency
      * @param string $beneficiaryId
      * @param string $amount
@@ -473,6 +478,25 @@ class Payment implements EntityInterface
     public function setPayerDetailsSource($payerDetailsSource)
     {
         $this->payerDetailsSource = $payerDetailsSource;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUniqueRequestId()
+    {
+        return $this->uniqueRequestId;
+    }
+
+    /**
+     * @param string $uniqueRequestId
+     *
+     * @return $this
+     */
+    public function setUniqueRequestId($uniqueRequestId)
+    {
+        $this->uniqueRequestId = $uniqueRequestId;
         return $this;
     }
 }


### PR DESCRIPTION
I also updated versions of symfony/yaml and symfony/event-dispatcher to newer versions. It seems it does work with new versions as well.