### PR TITLE
TCC-13306: New Conversion Calls: cancel, date_change, split

### DIFF
--- a/src/Model/CancelledConversion.php
+++ b/src/Model/CancelledConversion.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace CurrencyCloud\Model;
+
+use DateTime;
+
+class CancelledConversion
+{
+
+    /**
+     * @var string
+     */
+    private $account_id;
+    /**
+     * @var string
+     */
+    private $contact_id;
+    /**
+     * @var string
+     */
+    private $event_account_id;
+    /**
+     * @var string
+     */
+    private $event_contact_id;
+    /**
+     * @var string
+     */
+    private $conversion_id;
+
+    /**
+     * @var string
+     */
+    private $event_type;
+    /**
+     * @var string
+     */
+    private $amount;
+
+    /**
+     * @var string
+     */
+    private $currency;
+    /**
+     * @var string
+     */
+    private $notes;
+
+    /**
+     * @var DateTime
+     */
+    private $event_date_time;
+
+
+    /**
+     * @return string
+     */
+    public function getAccountId()
+    {
+        return $this->account_id;
+    }
+
+    /**
+     * @param string $account_id
+     * @return CancelledConversion
+     */
+    public function setAccountId($account_id)
+    {
+        $this->account_id = $account_id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContactId()
+    {
+        return $this->contact_id;
+    }
+
+    /**
+     * @param string $contact_id
+     * @return CancelledConversion
+     */
+    public function setContactId($contact_id)
+    {
+        $this->contact_id = $contact_id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEventAccountId()
+    {
+        return $this->event_account_id;
+    }
+
+    /**
+     * @param string $event_account_id
+     * @return CancelledConversion
+     */
+    public function setEventAccountId($event_account_id)
+    {
+        $this->event_account_id = $event_account_id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEventContactId()
+    {
+        return $this->event_contact_id;
+    }
+
+    /**
+     * @param string $event_contact_id
+     * @return CancelledConversion
+     */
+    public function setEventContactId($event_contact_id)
+    {
+        $this->event_contact_id = $event_contact_id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getConversionId()
+    {
+        return $this->conversion_id;
+    }
+
+    /**
+     * @param string $conversion_id
+     * @return CancelledConversion
+     */
+    public function setConversionId($conversion_id)
+    {
+        $this->conversion_id = $conversion_id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEventType()
+    {
+        return $this->event_type;
+    }
+
+    /**
+     * @param string $event_type
+     * @return CancelledConversion
+     */
+    public function setEventType($event_type)
+    {
+        $this->event_type = $event_type;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param string $amount
+     * @return CancelledConversion
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+
+    /**
+     * @param string $currency
+     * @return CancelledConversion
+     */
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNotes()
+    {
+        return $this->notes;
+    }
+
+    /**
+     * @param string $notes
+     * @return CancelledConversion
+     */
+    public function setNotes($notes)
+    {
+        $this->notes = $notes;
+        return $this;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getEventDateTime()
+    {
+        return $this->event_date_time;
+    }
+
+    /**
+     * @param DateTime $event_date_time
+     * @return CancelledConversion
+     */
+    public function setEventDateTime($event_date_time)
+    {
+        $this->event_date_time = $event_date_time;
+        return $this;
+    }
+
+}

--- a/src/Model/Conversion.php
+++ b/src/Model/Conversion.php
@@ -152,6 +152,14 @@ class Conversion
     /**
      * @return string
      */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * @return string
+     */
     public function getAccountId()
     {
         return $this->accountId;

--- a/src/Model/ConversionDateChanged.php
+++ b/src/Model/ConversionDateChanged.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace CurrencyCloud\Model;
+
+use DateTime;
+
+class ConversionDateChanged
+{
+
+
+    /**
+     * @var string
+     */
+    private $conversion_id;
+
+    /**
+     * @var string
+     */
+    private $amount;
+
+    /**
+     * @var string
+     */
+    private $currency;
+
+
+    /**
+     * @var DateTime
+     */
+    private $new_conversion_date;
+
+
+    /**
+     * @var DateTime
+     */
+    private $new_settlement_date;
+
+
+    /**
+     * @var DateTime
+     */
+    private $old_conversion_date;
+
+    /**
+     * @return string
+     */
+    public function getConversionId()
+    {
+        return $this->conversion_id;
+    }
+
+    /**
+     * @param string $conversion_id
+     * @return ConversionDateChanged
+     */
+    public function setConversionId($conversion_id)
+    {
+        $this->conversion_id = $conversion_id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param string $amount
+     * @return ConversionDateChanged
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+
+    /**
+     * @param string $currency
+     * @return ConversionDateChanged
+     */
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
+        return $this;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getNewConversionDate()
+    {
+        return $this->new_conversion_date;
+    }
+
+    /**
+     * @param DateTime $new_conversion_date
+     * @return ConversionDateChanged
+     */
+    public function setNewConversionDate($new_conversion_date)
+    {
+        $this->new_conversion_date = $new_conversion_date;
+        return $this;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getNewSettlementDate()
+    {
+        return $this->new_settlement_date;
+    }
+
+    /**
+     * @param DateTime $new_settlement_date
+     * @return ConversionDateChanged
+     */
+    public function setNewSettlementDate($new_settlement_date)
+    {
+        $this->new_settlement_date = $new_settlement_date;
+        return $this;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getOldConversionDate()
+    {
+        return $this->old_conversion_date;
+    }
+
+    /**
+     * @param DateTime $old_conversion_date
+     * @return ConversionDateChanged
+     */
+    public function setOldConversionDate($old_conversion_date)
+    {
+        $this->old_conversion_date = $old_conversion_date;
+        return $this;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getOldSettlementDate()
+    {
+        return $this->old_settlement_date;
+    }
+
+    /**
+     * @param DateTime $old_settlement_date
+     * @return ConversionDateChanged
+     */
+    public function setOldSettlementDate($old_settlement_date)
+    {
+        $this->old_settlement_date = $old_settlement_date;
+        return $this;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getEventDateTime()
+    {
+        return $this->event_date_time;
+    }
+
+    /**
+     * @param DateTime $event_date_time
+     * @return ConversionDateChanged
+     */
+    public function setEventDateTime($event_date_time)
+    {
+        $this->event_date_time = $event_date_time;
+        return $this;
+    }
+
+
+    /**
+     * @var DateTime
+     */
+    private $old_settlement_date;
+
+
+    /**
+     * @var DateTime
+     */
+    private $event_date_time;
+
+
+}

--- a/src/Model/ConversionSplit.php
+++ b/src/Model/ConversionSplit.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace CurrencyCloud\Model;
+
+use DateTime;
+use CurrencyCloud\Model\Conversion;
+
+class ConversionSplit
+{
+
+    /**
+     * @var Conversion
+     */
+    private $parent_conversion;
+
+    /**
+     * @var Conversion
+     */
+    private $child_conversion;
+
+
+    /**
+     * @return \CurrencyCloud\Model\Conversion
+     */
+    public function getParentConversion()
+    {
+        return $this->parent_conversion;
+    }
+
+    /**
+     * @param \CurrencyCloud\Model\Conversion $parent_conversion
+     * @return ConversionSplit
+     */
+    public function setParentConversion($parent_conversion)
+    {
+        $this->parent_conversion = $parent_conversion;
+        return $this;
+    }
+
+    /**
+     * @return \CurrencyCloud\Model\Conversion
+     */
+    public function getChildConversion()
+    {
+        return $this->child_conversion;
+    }
+
+    /**
+     * @param \CurrencyCloud\Model\Conversion $child_conversion
+     * @return ConversionSplit
+     */
+    public function setChildConversion($child_conversion)
+    {
+        $this->child_conversion = $child_conversion;
+        return $this;
+    }
+
+}

--- a/tests/fixtures/Conversions/can_cancel.yaml
+++ b/tests/fixtures/Conversions/can_cancel.yaml
@@ -1,0 +1,16 @@
+-
+  request:
+    method: POST
+    url: https://devapi.currencycloud.com/v2/conversions/0ff0ea60-d976-4c7f-ad7f-3eb94da68452/cancel
+    body: id=0ff0ea60-d976-4c7f-ad7f-3eb94da68452
+    headers:
+      Host: devapi.currencycloud.com
+      X-Auth-Token: e5070d4a16c5ffe4ed9fb268a2a716be
+  response:
+    status: 200
+    headers:
+      Date: Sat, 25 Apr 2015 09:21:00 GMT
+      Content-Type: application/json
+      Content-Size: 1019
+      X-Request-Id: '2771948673934289802'
+    body: '{"account_id":"f054ef5d-3cfa-4d2c-ad84-caee50e5fc83","contact_id":"0ff0ea60-d976-4c7f-ad7f-3eb94da68452","event_account_id":"f054ef5d-3cfa-4d2c-ad84-caee50e5fc83","event_contact_id":"0ff0ea60-d976-4c7f-ad7f-3eb94da68452","conversion_id":"740a64c5-fd0a-47d4-b690-51310501f470","event_type":"self_service_cancellation","amount":"-1.00","currency":"GBP","notes":"Cancelduetoveryimportantreason","event_date_time":"2018-05-01T09:22:11+00:00"}';

--- a/tests/fixtures/Conversions/can_date_change.yaml
+++ b/tests/fixtures/Conversions/can_date_change.yaml
@@ -1,0 +1,16 @@
+-
+  request:
+    method: POST
+    url: https://devapi.currencycloud.com/v2/conversions/13909849-1dbd-45c1-83c7-25930132f02c/date_change
+    body: new_settlement_date=2028-05-12
+    headers:
+      Host: devapi.currencycloud.com
+      X-Auth-Token: e5070d4a16c5ffe4ed9fb268a2a716be
+  response:
+    status: 200
+    headers:
+      Date: Sat, 25 Apr 2015 09:21:00 GMT
+      Content-Type: application/json
+      Content-Size: 1019
+      X-Request-Id: '2771948673934289802'
+    body: '{"conversion_id":"13909849-1dbd-45c1-83c7-25930132f02c","amount":"19.12","currency":"GBP","new_conversion_date":"2018-05-14T00:00:00+00:00","new_settlement_date":"2018-05-14T15:30:00+00:00","old_conversion_date":"2018-05-03T00:00:00+00:00","old_settlement_date":"2018-05-03T15:30:00+00:00","event_date_time":"2018-05-01T14:08:17+00:00"}';

--- a/tests/fixtures/Conversions/can_split.yaml
+++ b/tests/fixtures/Conversions/can_split.yaml
@@ -1,0 +1,16 @@
+-
+  request:
+    method: POST
+    url: https://devapi.currencycloud.com/v2/conversions/13909849-1dbd-45c1-83c7-25930132f02c/split
+    body: amount=100
+    headers:
+      Host: devapi.currencycloud.com
+      X-Auth-Token: e5070d4a16c5ffe4ed9fb268a2a716be
+  response:
+    status: 200
+    headers:
+      Date: Sat, 25 Apr 2015 09:21:00 GMT
+      Content-Type: application/json
+      Content-Size: 1019
+      X-Request-Id: '2771948673934289802'
+    body: '{"parent_conversion":{"id":"13909849-1dbd-45c1-83c7-25930132f02c","short_reference":"20180501-JLWFFS","sell_amount":"7031.75","sell_currency":"GBP","buy_amount":"9900.00","buy_currency":"USD","settlement_date":"2018-05-14T15:30:00+00:00","conversion_date":"2018-05-14T00:00:00+00:00","status":"awaiting_funds"},"child_conversion":{"id":"bd054ea4-0e81-48de-bb49-b0373ae34180","short_reference":"20180501-XGYQDR","sell_amount":"71.03","sell_currency":"GBP","buy_amount":"100.00","buy_currency":"USD","settlement_date":"2018-05-14T15:30:00+00:00","conversion_date":"2018-05-14T00:00:00+00:00","status":"awaiting_funds"}}'


### PR DESCRIPTION
New Conversion Calls: cancel, date_change, split as per swagger documentation update here:
https://github.com/CurrencyCloud/currencycloud-swagger/pull/4

**NOTE - there is already a PR open for the Conversion self-service updates here:
https://github.com/CurrencyCloud/currencycloud-swagger/pull/3