### PR TITLE
fixed payer Address Type #84

### DIFF
--- a/src/Model/Payer.php
+++ b/src/Model/Payer.php
@@ -28,7 +28,7 @@ class Payer
      */
     private $lastName;
     /**
-     * @var array|null
+     * @var string|null
      */
     private $address;
     /**
@@ -73,7 +73,7 @@ class Payer
      * @param string|null $companyName
      * @param string|null $firstName
      * @param string|null $lastName
-     * @param array|null $address
+     * @param string|null $address
      * @param string|null $city
      * @param string|null $stateOrProvince
      * @param string|null $country
@@ -89,7 +89,7 @@ class Payer
         $companyName = null,
         $firstName = null,
         $lastName = null,
-        array $address = null,
+        $address = null,
         $city = null,
         $stateOrProvince = null,
         $country = null,
@@ -157,7 +157,7 @@ class Payer
     }
 
     /**
-     * @return array|null
+     * @return string|null
      */
     public function getAddress()
     {
@@ -281,7 +281,7 @@ class Payer
     }
 
     /**
-     * @param array|null $address
+     * @param string|null $address
      *
      * @return $this
      */


### PR DESCRIPTION
 Argument 5 passed to CurrencyCloud\Model\Payer::__construct() must be of the type array or null, string given, called in /home/vagrant/code/laravel/Lintium/vendor/currency-cloud/client/src/EntryPoint/PayersEntryPoint.php on line 47

**this error is thrown whenever i request a payer , i adjusted the return type to be a string.
 as i compared it to the actual value and that is a string** 