### PR TITLE
UpdateFile PaymentsEntryPoint.php

### DIFF
--- a/src/EntryPoint/PaymentsEntryPoint.php
+++ b/src/EntryPoint/PaymentsEntryPoint.php
@@ -69,7 +69,7 @@ class PaymentsEntryPoint extends AbstractEntityEntryPoint
         $paymentDate = $payment->getPaymentDate();
         return $common + [
             'reference' => $payment->getReference(),
-            'payment_date' => (null === $paymentDate) ? $paymentDate : $paymentDate->format(DateTime::RFC3339),
+            'payment_date' => (null === $paymentDate) ? $paymentDate : $paymentDate->format('Y-m-d'),
             'payment_type' => $payment->getPaymentType()
         ];
     }


### PR DESCRIPTION
On line 72, if $paymentDate return DateTime with specific payment date, and it's been format to "Y-m-d\TH:i:sP" the http request will result to a bed http request since the require date format is 'Y-m-d' (without TH:i:sP). The quick fix is to change the format on line 72 to 'Y-,-d' instead of `DateTime::RFC3339`. The better way to make this work is to change the required date format to "Y-m-d\TH:i:sP" so we can continue use `DateTime::RFC3339`.

Check the payment_date field's description here https://www.currencycloud.com/developers/docs/item/create-payment/

> Instructed date of payment. Any valid ISO 8601 format, eg. "2017-12-31". 