### PR TITLE
Removes all references to partner_status for conversions endpoints 

### DIFF
--- a/src/Criteria/ConversionReportCriteria.php
+++ b/src/Criteria/ConversionReportCriteria.php
@@ -58,10 +58,6 @@ class ConversionReportCriteria
      */
     private $clientStatus;
     /*
-     * @var string|null
-     */
-    private $partnerStatus;
-    /*
      * @var DateTime
      */
     private $conversionDateFrom;
@@ -334,24 +330,6 @@ class ConversionReportCriteria
     public function setClientStatus($clientStatus)
     {
         $this->clientStatus = $clientStatus;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPartnerStatus()
-    {
-        return $this->partnerStatus;
-    }
-
-    /**
-     * @param string $partnerStatus
-     * @return $this
-     */
-    public function setPartnerStatus($partnerStatus)
-    {
-        $this->partnerStatus = $partnerStatus;
         return $this;
     }
 

--- a/src/EntryPoint/ConversionsEntryPoint.php
+++ b/src/EntryPoint/ConversionsEntryPoint.php
@@ -78,7 +78,6 @@ class ConversionsEntryPoint extends AbstractEntryPoint
             ->setSettlementDate(new DateTime($response->settlement_date))
             ->setConversionDate(new DateTime($response->conversion_date))
             ->setStatus($response->status)
-            ->setPartnerStatus($response->partner_status)
             ->setCurrencyPair($response->currency_pair)
             ->setBuyCurrency($response->buy_currency)
             ->setSellCurrency($response->sell_currency)
@@ -248,7 +247,6 @@ class ConversionsEntryPoint extends AbstractEntryPoint
         return [
             'short_reference' => $criteria->getShortReference(),
             'status' => $criteria->getStatus(),
-            'partner_status' => $criteria->getParentStatus(),
             'buy_currency' => $criteria->getBuyCurrency(),
             'sell_currency' => $criteria->getSellCurrency(),
             'conversion_ids' => (null === $conversionIds) ? null : implode(',', $conversionIds),

--- a/src/EntryPoint/ReportsEntryPoint.php
+++ b/src/EntryPoint/ReportsEntryPoint.php
@@ -50,7 +50,6 @@ class ReportsEntryPoint extends AbstractEntityEntryPoint
             'partner_sell_amount_from' => $conversionReportCriteria->getPartnerSellAmountFrom(),
             'partner_sell_amount_to' => $conversionReportCriteria->getPartnerSellAmountTo(),
             'client_status' => $conversionReportCriteria->getClientStatus(),
-            'partner_status' => $conversionReportCriteria->getPartnerStatus(),
             'conversion_date_from' => $conversionReportCriteria->getConversionDateFrom(),
             'conversion_date_to' => $conversionReportCriteria->getConversionDateTo(),
             'settlement_date_from' => $conversionReportCriteria->getSettlementDateFrom(),

--- a/src/Model/Conversion.php
+++ b/src/Model/Conversion.php
@@ -40,10 +40,6 @@ class Conversion
     /**
      * @var string
      */
-    private $partnerStatus;
-    /**
-     * @var string
-     */
     private $currencyPair;
     /**
      * @var string
@@ -272,25 +268,6 @@ class Conversion
     public function setStatus($status)
     {
         $this->status = $status;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPartnerStatus()
-    {
-        return $this->partnerStatus;
-    }
-
-    /**
-     * @param string $partnerStatus
-     *
-     * @return $this
-     */
-    public function setPartnerStatus($partnerStatus)
-    {
-        $this->partnerStatus = $partnerStatus;
         return $this;
     }
 

--- a/src/Model/ReportSearchParams.php
+++ b/src/Model/ReportSearchParams.php
@@ -94,10 +94,6 @@ class ReportSearchParams {
      */
     private $clientStatus;
     /*
-     * @var string|null
-     */
-    private $partnerStatus;
-    /*
      * @var DateTime
      */
     private $conversionDateFrom;
@@ -202,7 +198,6 @@ class ReportSearchParams {
         $this->partnerSellAmountFrom = $this->getValue($data, 'partner_sell_amount_from');
         $this->partnerSellAmountTo = $this->getValue($data, 'partner_sell_amount_to');
         $this->clientStatus = $this->getValue($data, 'client_status');
-        $this->partnerStatus = $this->getValue($data, 'partner_status');
         $this->conversionDateFrom = $this->getValue($data, 'conversion_date_from');
         $this->conversionDateTo = $this->getValue($data, 'conversion_date_to');
         $this->settlementDateFrom = $this->getValue($data, 'settlement_date_from');
@@ -407,14 +402,6 @@ class ReportSearchParams {
     public function getClientStatus()
     {
         return $this->clientStatus;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getPartnerStatus()
-    {
-        return $this->partnerStatus;
     }
 
     /**

--- a/tests/EntryPoint/ConversionsEntryPointTest.php
+++ b/tests/EntryPoint/ConversionsEntryPointTest.php
@@ -21,7 +21,7 @@ class ConversionsEntryPointTest extends BaseCurrencyCloudTestCase
      */
     public function canFindWhenAllParamsAreNull()
     {
-        $data = '{"conversions":[{"id":"c9b6b851-10f9-4bbf-881e-1d8a49adf7d8","unique_request_id":null,"account_id":"0386e472-8d2b-45a8-9c14-a393dce5bf3a","creator_contact_id":"ac743762-5860-4b78-9c6a-82c5bca68867","short_reference":"20140507-VRTNFC","settlement_date":"2014-05-21T14:00:00Z","conversion_date":"2014-05-21T14:00:00Z","status":"awaiting_funds","partner_status":"awaiting_funds","currency_pair":"GBPUSD","buy_currency":"GBP","sell_currency":"USD","fixed_side":"buy","partner_buy_amount":"1000.00","partner_sell_amount":"1587.80","client_buy_amount":"1000.00","client_sell_amount":"1594.90","mid_market_rate":"1.5868","core_rate":"1.5871","partner_rate":"1.5878","client_rate":"1.5949","deposit_required":true,"deposit_amount":"47.85","deposit_currency":"GBP","deposit_status":"awaiting_deposit","deposit_required_at":"2013-05-09T14:00:00Z","payment_ids":["b934794f-d810-4b4a-b360-5a0f47b7126e"],"created_at":"2014-01-12T00:00:00+00:00","updated_at":"2014-01-12T00:00:00+00:00"}],"pagination":{"total_entries":1,"total_pages":1,"current_page":1,"per_page":25,"previous_page":-1,"next_page":2,"order":"created_at","order_asc_desc":"asc"}}';
+        $data = '{"conversions":[{"id":"c9b6b851-10f9-4bbf-881e-1d8a49adf7d8","unique_request_id":null,"account_id":"0386e472-8d2b-45a8-9c14-a393dce5bf3a","creator_contact_id":"ac743762-5860-4b78-9c6a-82c5bca68867","short_reference":"20140507-VRTNFC","settlement_date":"2014-05-21T14:00:00Z","conversion_date":"2014-05-21T14:00:00Z","status":"awaiting_funds","currency_pair":"GBPUSD","buy_currency":"GBP","sell_currency":"USD","fixed_side":"buy","partner_buy_amount":"1000.00","partner_sell_amount":"1587.80","client_buy_amount":"1000.00","client_sell_amount":"1594.90","mid_market_rate":"1.5868","core_rate":"1.5871","partner_rate":"1.5878","client_rate":"1.5949","deposit_required":true,"deposit_amount":"47.85","deposit_currency":"GBP","deposit_status":"awaiting_deposit","deposit_required_at":"2013-05-09T14:00:00Z","payment_ids":["b934794f-d810-4b4a-b360-5a0f47b7126e"],"created_at":"2014-01-12T00:00:00+00:00","updated_at":"2014-01-12T00:00:00+00:00"}],"pagination":{"total_entries":1,"total_pages":1,"current_page":1,"per_page":25,"previous_page":-1,"next_page":2,"order":"created_at","order_asc_desc":"asc"}}';
 
 
         $entryPoint = new ConversionsEntryPoint($this->getMockedClient(
@@ -31,7 +31,6 @@ class ConversionsEntryPointTest extends BaseCurrencyCloudTestCase
             [
                 'short_reference' => null,
                 'status' => null,
-                'partner_status' => null,
                 'buy_currency' => null,
                 'sell_currency' => null,
                 'conversion_ids' => null,
@@ -64,7 +63,7 @@ class ConversionsEntryPointTest extends BaseCurrencyCloudTestCase
      */
     public function canFindWhenAllParamsAreNonNull()
     {
-        $data = '{"conversions":[{"id":"c9b6b851-10f9-4bbf-881e-1d8a49adf7d8","unique_request_id":null,"account_id":"0386e472-8d2b-45a8-9c14-a393dce5bf3a","creator_contact_id":"ac743762-5860-4b78-9c6a-82c5bca68867","short_reference":"20140507-VRTNFC","settlement_date":"2014-05-21T14:00:00Z","conversion_date":"2014-05-21T14:00:00Z","status":"awaiting_funds","partner_status":"awaiting_funds","currency_pair":"GBPUSD","buy_currency":"GBP","sell_currency":"USD","fixed_side":"buy","partner_buy_amount":"1000.00","partner_sell_amount":"1587.80","client_buy_amount":"1000.00","client_sell_amount":"1594.90","mid_market_rate":"1.5868","core_rate":"1.5871","partner_rate":"1.5878","client_rate":"1.5949","deposit_required":true,"deposit_amount":"47.85","deposit_currency":"GBP","deposit_status":"awaiting_deposit","deposit_required_at":"2013-05-09T14:00:00Z","payment_ids":["b934794f-d810-4b4a-b360-5a0f47b7126e"],"created_at":"2014-01-12T00:00:00+00:00","updated_at":"2014-01-12T00:00:00+00:00"}],"pagination":{"total_entries":1,"total_pages":1,"current_page":1,"per_page":25,"previous_page":-1,"next_page":2,"order":"created_at","order_asc_desc":"asc"}}';
+        $data = '{"conversions":[{"id":"c9b6b851-10f9-4bbf-881e-1d8a49adf7d8","unique_request_id":null,"account_id":"0386e472-8d2b-45a8-9c14-a393dce5bf3a","creator_contact_id":"ac743762-5860-4b78-9c6a-82c5bca68867","short_reference":"20140507-VRTNFC","settlement_date":"2014-05-21T14:00:00Z","conversion_date":"2014-05-21T14:00:00Z","status":"awaiting_funds","currency_pair":"GBPUSD","buy_currency":"GBP","sell_currency":"USD","fixed_side":"buy","partner_buy_amount":"1000.00","partner_sell_amount":"1587.80","client_buy_amount":"1000.00","client_sell_amount":"1594.90","mid_market_rate":"1.5868","core_rate":"1.5871","partner_rate":"1.5878","client_rate":"1.5949","deposit_required":true,"deposit_amount":"47.85","deposit_currency":"GBP","deposit_status":"awaiting_deposit","deposit_required_at":"2013-05-09T14:00:00Z","payment_ids":["b934794f-d810-4b4a-b360-5a0f47b7126e"],"created_at":"2014-01-12T00:00:00+00:00","updated_at":"2014-01-12T00:00:00+00:00"}],"pagination":{"total_entries":1,"total_pages":1,"current_page":1,"per_page":25,"previous_page":-1,"next_page":2,"order":"created_at","order_asc_desc":"asc"}}';
 
         $createdAtFrom = (new DateTime())->modify('-1 hour');
         $createdAtTo = (new DateTime())->modify('-2 hour');
@@ -99,7 +98,6 @@ class ConversionsEntryPointTest extends BaseCurrencyCloudTestCase
             [
                 'short_reference' => 'A',
                 'status' => 'P',
-                'partner_status' => 'B',
                 'buy_currency' => 'C',
                 'sell_currency' => 'D',
                 'conversion_ids' => 'E,F',
@@ -128,7 +126,7 @@ class ConversionsEntryPointTest extends BaseCurrencyCloudTestCase
      */
     public function canRetrieve()
     {
-        $data = '{"id":"c9b6b851-10f9-4bbf-881e-1d8a49adf7d8","unique_request_id":null,"account_id":"0386e472-8d2b-45a8-9c14-a393dce5bf3a","creator_contact_id":"ac743762-5860-4b78-9c6a-82c5bca68867","short_reference":"20140507-VRTNFC","settlement_date":"2014-05-21T14:00:00Z","conversion_date":"2014-05-21T14:00:00Z","status":"awaiting_funds","partner_status":"awaiting_funds","currency_pair":"GBPUSD","buy_currency":"GBP","sell_currency":"USD","fixed_side":"buy","partner_buy_amount":"1000.00","partner_sell_amount":"1587.80","client_buy_amount":"1000.00","client_sell_amount":"1594.90","mid_market_rate":"1.5868","core_rate":"1.5871","partner_rate":"1.5878","client_rate":"1.5949","deposit_required":true,"deposit_amount":"47.85","deposit_currency":"GBP","deposit_status":"awaiting_deposit","deposit_required_at":"2013-05-09T14:00:00Z","payment_ids":["b934794f-d810-4b4a-b360-5a0f47b7126e"],"created_at":"2014-01-12T00:00:00+00:00","updated_at":"2014-01-12T00:00:00+00:00"}';
+        $data = '{"id":"c9b6b851-10f9-4bbf-881e-1d8a49adf7d8","unique_request_id":null,"account_id":"0386e472-8d2b-45a8-9c14-a393dce5bf3a","creator_contact_id":"ac743762-5860-4b78-9c6a-82c5bca68867","short_reference":"20140507-VRTNFC","settlement_date":"2014-05-21T14:00:00Z","conversion_date":"2014-05-21T14:00:00Z","status":"awaiting_funds","currency_pair":"GBPUSD","buy_currency":"GBP","sell_currency":"USD","fixed_side":"buy","partner_buy_amount":"1000.00","partner_sell_amount":"1587.80","client_buy_amount":"1000.00","client_sell_amount":"1594.90","mid_market_rate":"1.5868","core_rate":"1.5871","partner_rate":"1.5878","client_rate":"1.5949","deposit_required":true,"deposit_amount":"47.85","deposit_currency":"GBP","deposit_status":"awaiting_deposit","deposit_required_at":"2013-05-09T14:00:00Z","payment_ids":["b934794f-d810-4b4a-b360-5a0f47b7126e"],"created_at":"2014-01-12T00:00:00+00:00","updated_at":"2014-01-12T00:00:00+00:00"}';
 
 
         $entryPoint = new ConversionsEntryPoint($this->getMockedClient(
@@ -563,7 +561,6 @@ class ConversionsEntryPointTest extends BaseCurrencyCloudTestCase
                "fixed_side": "buy",
                "core_rate": "0.8059",
                "partner_rate": "",
-               "partner_status": "funds_arrived",
                "partner_buy_amount": "0.00",
                "partner_sell_amount": "0.00",
                "client_rate": "0.8059",

--- a/tests/EntryPoint/ReportsEntryPointTest.php
+++ b/tests/EntryPoint/ReportsEntryPointTest.php
@@ -56,7 +56,6 @@ class ReportsEntryPointTest extends BaseCurrencyCloudTestCase {
                     'partner_sell_amount_from' => null,
                     'partner_sell_amount_to' => null,
                     'client_status' => null,
-                    'partner_status' => null,
                     'conversion_date_from' => null,
                     'conversion_date_to' => null,
                     'settlement_date_from' => null,


### PR DESCRIPTION
The partner_status parameter has been removed from the query params and responses of the conversions endpoints, so the SDK has been updated to reflect this change