### PR TITLE
update possible symfony/yaml versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": ">=7.2",
     "guzzlehttp/guzzle": "~6.1||~7.0",
-    "symfony/yaml": "^2.7||^3.0||^4.0",
+    "symfony/yaml": "^2.7||^3.0||^4.0||^5.0||^6.0",
     "symfony/event-dispatcher": "^5.0"
   },
   "require-dev": {


### PR DESCRIPTION
We wanted to add the currency cloud package to our project, but we already use Symfony 5.4 and will soon upgrade to Smyonfy 6.0. To allow the update I bumped the version of the `symfony/yaml` package