### PR TITLE
PHP 8 and Symfony 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.3
   - 7.4
+  - 8.0
 
 before_script:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ it will be far easier to simply make use of Composer to do the dependency manage
 
 
 ### Supported PHP version
-This library aims to support and is tested against PHP 7.4.
+This library aims to support and is tested against PHP 7.4 and PHP 8.0.
 
 ## Installation
 The recommended way to install Currencycloud SDK is through

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
   "require": {
     "php": ">=7.2",
     "guzzlehttp/guzzle": "~6.1||~7.0",
-    "symfony/yaml": "^2.7||^3.0||^4.0||^5.0",
-    "symfony/event-dispatcher": "^5.0"
+    "symfony/yaml": "^2.7||^3.0||^4.0||^5.0||^6.0",
+    "symfony/event-dispatcher": "^5.0||^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
-    "php-vcr/php-vcr": "~1.2",
-    "php-vcr/phpunit-testlistener-vcr": "^3.2"
+    "php-vcr/php-vcr": "~1.2"
   },
   "suggest": {
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,10 +17,6 @@
         </testsuite>
     </testsuites>
 
-    <listeners>
-        <listener class="VCR\PHPUnit\TestListener\VCRTestListener" file="vendor/php-vcr/phpunit-testlistener-vcr/src/VCRTestListener.php" />
-    </listeners>
-
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>

--- a/tests/BaseCurrencyCloudVCRTestCase.php
+++ b/tests/BaseCurrencyCloudVCRTestCase.php
@@ -31,9 +31,23 @@ use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use VCR\VCR;
 
 class BaseCurrencyCloudVCRTestCase extends BaseCurrencyCloudTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        VCR::turnOn();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        VCR::turnOff();
+    }
 
     /**
      * @param string $loginId

--- a/tests/VCR/Actions/Test.php
+++ b/tests/VCR/Actions/Test.php
@@ -5,16 +5,15 @@ namespace CurrencyCloud\Tests\VCR\Actions;
 use CurrencyCloud\Model\Beneficiary;
 use CurrencyCloud\Model\Pagination;
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase
 {
-
-    /**
-     * @vcr Actions/can_first.yaml
-     * @test
-     */
+    /** @test */
     public function canFirst()
     {
+        VCR::insertCassette('Actions/can_first.yaml');
+
         $beneficiaries =
             $this->getAuthenticatedClient()
                 ->beneficiaries()
@@ -34,12 +33,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($beneficiaries->getPagination(), $dummy['pagination']);
     }
 
-    /**
-     * @vcr Actions/can_find.yaml
-     * @test
-     */
+    /** @test */
     public function canFind()
     {
+        VCR::insertCassette('Actions/can_find.yaml');
+
         $beneficiaries = $this->getAuthenticatedClient()
             ->beneficiaries()
             ->find();
@@ -55,12 +53,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($beneficiaries->getPagination(), $dummy['pagination']);
     }
 
-    /**
-     * @vcr Actions/can_retrieve.yaml
-     * @test
-     */
+    /** @test */
     public function canRetrieve()
     {
+        VCR::insertCassette('Actions/can_retrieve.yaml');
+
         $beneficiary = $this->getAuthenticatedClient()
             ->beneficiaries()
             ->retrieve('081596c9-02de-483e-9f2a-4cf55dcdf98c');
@@ -73,12 +70,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($beneficiary, $dummy);
     }
 
-    /**
-     * @vcr Actions/can_delete.yaml
-     * @test
-     */
+    /** @test */
     public function canDelete()
     {
+        VCR::insertCassette('Actions/can_delete.yaml');
+
         $beneficiary = $this->getAuthenticatedClient()
             ->beneficiaries()
             ->retrieve('081596c9-02de-483e-9f2a-4cf55dcdf98c');
@@ -97,12 +93,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
 
     }
 
-    /**
-     * @vcr Actions/can_create.yaml
-     * @test
-     */
+    /** @test */
     public function canCreate()
     {
+        VCR::insertCassette('Actions/can_create.yaml');
+
         $beneficiary =
             Beneficiary::create('Test User', 'GB', 'GBP', 'Test User')
                 ->setAccountNumber('12345678')
@@ -122,12 +117,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($beneficiary, $dummy);
     }
 
-    /**
-     * @vcr Actions/can_validate_beneficiaries.yaml
-     * @test
-     */
+    /** @test */
     public function canValidateBeneficiaries()
     {
+        VCR::insertCassette('Actions/can_validate_beneficiaries.yaml');
+
         $beneficiary =
             Beneficiary::createForValidate('GB', 'GBP', 'GB')
                 ->setAccountNumber('12345678')
@@ -147,12 +141,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($beneficiary, $dummy);
     }
 
-    /**
-     * @vcr Actions/can_update.yaml
-     * @test
-     */
+    /** @test */
     public function canUpdate()
     {
+        VCR::insertCassette('Actions/can_update.yaml');
+
         $client = $this->getAuthenticatedClient();
 
         $beneficiary =
@@ -180,12 +173,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($beneficiary, $dummy);
     }
 
-    /**
-     * @vcr Actions/can_current.yaml
-     * @test
-     */
+    /** @test */
     public function canCurrent()
     {
+        VCR::insertCassette('Actions/can_current.yaml');
+
         $account = $this->getAuthenticatedClient()
             ->accounts()->current();
 
@@ -197,12 +189,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($account, $dummy);
     }
 
-    /**
-     * @vcr Actions/can_use_currency_to_retrieve_balance.yaml
-     * @test
-     */
+    /** @test */
     public function canUseCurrencyToRetrieveBalance()
     {
+        VCR::insertCassette('Actions/can_use_currency_to_retrieve_balance.yaml');
+
         $balance = $this->getAuthenticatedClient()
             ->balances()->retrieve('GBP');
 

--- a/tests/VCR/Authentication/Test.php
+++ b/tests/VCR/Authentication/Test.php
@@ -4,16 +4,15 @@ namespace CurrencyCloud\Tests\VCR\Authentication;
 
 use CurrencyCloud\Model\Beneficiaries;
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase
 {
 
-    /**
-     * @vcr Authentication/can_be_closed.yaml
-     * @test
-     */
+    /** @test */
     public function canBeClosed()
     {
+        VCR::insertCassette('Authentication/can_be_closed.yaml');
 
         $client = $this->getClient();
         $client->getSession()->setAuthToken('2ec8a86c8cf6e0378a20ca6793f3260c');
@@ -22,12 +21,10 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->assertNull($client->getSession()->getAuthToken());
     }
 
-    /**
-     * @vcr Authentication/can_use_just_a_token.yaml
-     * @test
-     */
+    /** @test */
     public function canUseJustToken()
     {
+        VCR::insertCassette('Authentication/can_use_just_a_token.yaml');
 
         $client = $this->getAuthenticatedClient('2ec8a86c8cf6e0378a20ca6793f3260c');
 
@@ -44,12 +41,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($beneficiaries->getPagination(), $dummy['pagination']);
     }
 
-    /**
-     * @vcr Authentication/happens_lazily.yaml
-     * @test
-     */
+    /** @test */
     public function happensLazily()
     {
+        VCR::insertCassette('Authentication/happens_lazily.yaml');
+
         $client = $this->getClient();
         $client->getSession()->setAuthToken("038022bcd2f372cac7bab448db7b5c3b");
 
@@ -66,12 +62,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->assertEquals("038022bcd2f372cac7bab448db7b5c3b", $client->getSession()->getAuthToken());
     }
 
-    /**
-     * @vcr Authentication/handles_session_timeout_error.yaml
-     * @test
-     */
+    /** @test */
     public function handlesSessionTimeoutError()
     {
+        VCR::insertCassette('Authentication/handles_session_timeout_error.yaml');
+
         $client = $this->getAuthenticatedClient();
 
         $beneficiaries = $client->beneficiaries()->find();

--- a/tests/VCR/Conversions/Test.php
+++ b/tests/VCR/Conversions/Test.php
@@ -6,14 +6,15 @@ use CurrencyCloud\Model\Conversion;
 use CurrencyCloud\Model\Pagination;
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
 use DateTime;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase {
 
-    /**
-     * @vcr Conversions/can_retrieve_conversion_profit_loss.yaml
-     * @test
-     */
-    public function canRetrieveConversionProfitLoss(){
+    /** @test */
+    public function canRetrieveConversionProfitLoss()
+    {
+        VCR::insertCassette('Conversions/can_retrieve_conversion_profit_loss.yaml');
+
         $conversionProfitLossCriteria = new ConversionProfitLossCriteria();
         $pagination = new Pagination();
 
@@ -39,11 +40,10 @@ class Test extends BaseCurrencyCloudVCRTestCase {
         $this->assertSame($dummy['pagination']['total_entries'], $conversionProfitLossCollection->getPagination()->getTotalEntries());
     }
 
-    /**
-     * @vcr Conversions/can_retrieve_conversion_date_change_quote.yaml
-     * @test
-     */
-    public function canRetrieveConversionDateChangeQuote(){
+    /** @test */
+    public function canRetrieveConversionDateChangeQuote()
+    {
+        VCR::insertCassette('Conversions/can_retrieve_conversion_date_change_quote.yaml');
 
         $conversionDateChangeQuote = $this->getAuthenticatedClient()->conversions()->retrieveDateChangeQuote('cef197c6-2192-4970-a2cf-d45ee046ae8c','2018-11-06');
 
@@ -63,11 +63,10 @@ class Test extends BaseCurrencyCloudVCRTestCase {
             $conversionDateChangeQuote->getNewSettlementDate()->format(DateTime::RFC3339));
     }
 
-    /**
-     * @vcr Conversions/can_retrieve_conversion_split_preview.yaml
-     * @test
-     */
-    public function canRetrieveConversionSplitPreview(){
+    /** @test */
+    public function canRetrieveConversionSplitPreview()
+    {
+        VCR::insertCassette('Conversions/can_retrieve_conversion_split_preview.yaml');
 
         $conversionConversionSplitPreview = $this->getAuthenticatedClient()->conversions()->retrieveSplitPreview('cef197c6-2192-4970-a2cf-d45ee046ae8c','35.46');
 
@@ -92,11 +91,10 @@ class Test extends BaseCurrencyCloudVCRTestCase {
         $this->assertSame($dummy['child_conversion']['status'], $conversionConversionSplitPreview->getChildConversion()->getStatus());
     }
 
-    /**
-     * @vcr Conversions/can_retrieve_conversion_split_history.yaml
-     * @test
-     */
-    public function canRetrieveConversionSplitHistory(){
+    /** @test */
+    public function canRetrieveConversionSplitHistory()
+    {
+        VCR::insertCassette('Conversions/can_retrieve_conversion_split_history.yaml');
 
         $conversionConversionSplitHistory = $this->getAuthenticatedClient()->conversions()->retrieveSplitHistory('24d2ee7f-c7a3-4181-979e-9c58dbace992');
 
@@ -131,11 +129,10 @@ class Test extends BaseCurrencyCloudVCRTestCase {
         }
     }
 
-    /**
-     * @vcr Conversions/can_retrieve_conversion_cancellation_quote.yaml
-     * @test
-     */
-    public function canRetrieveConversionCancellationQuote(){
+    /** @test */
+    public function canRetrieveConversionCancellationQuote()
+    {
+        VCR::insertCassette('Conversions/can_retrieve_conversion_cancellation_quote.yaml');
 
         $conversionCancellationQuote = $this->getAuthenticatedClient()->conversions()->retrieveCancellationQuote('9b29e56d-6a67-4470-a291-ee72b6371c32');
 

--- a/tests/VCR/Error/Test.php
+++ b/tests/VCR/Error/Test.php
@@ -11,16 +11,16 @@ use CurrencyCloud\Exception\NotFoundException;
 use CurrencyCloud\Exception\ToManyRequestsException;
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
 use Exception;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase
 {
 
-    /**
-     * @vcr Error/contains_full_details_for_api_error.yaml
-     * @test
-     */
+    /** @test */
     public function containsFullDetailForApiError()
     {
+        VCR::insertCassette('Error/contains_full_details_for_api_error.yaml');
+
         try {
             $this->getInvalidClient()
                 ->authenticate()
@@ -117,12 +117,10 @@ EOT;
         return parent::getClient($loginId, $apiKey);
     }
 
-    /**
-     * @vcr Error/is_raised_on_a_bad_request.yaml
-     * @test
-     */
+    /** @test */
     public function isRaisedOnABadRequest()
     {
+        VCR::insertCassette('Error/is_raised_on_a_bad_request.yaml');
 
         $this->setExpectedException(BadRequestException::class);
 
@@ -131,12 +129,10 @@ EOT;
             ->login();
     }
 
-    /**
-     * @vcr Error/is_raised_on_a_forbidden_request.yaml
-     * @test
-     */
+    /** @test */
     public function isRaisedOnAForbiddenRequest()
     {
+        VCR::insertCassette('Error/is_raised_on_a_forbidden_request.yaml');
 
         $this->setExpectedException(ForbiddenException::class);
 
@@ -145,12 +141,10 @@ EOT;
             ->login();
     }
 
-    /**
-     * @vcr Error/is_raised_on_an_internal_server_error.yaml
-     * @test
-     */
+    /** @test */
     public function isRaisedOnAnInternalServerError()
     {
+        VCR::insertCassette('Error/is_raised_on_an_internal_server_error.yaml');
 
         $this->setExpectedException(InternalApplicationException::class);
 
@@ -159,12 +153,10 @@ EOT;
             ->login();
     }
 
-    /**
-     * @vcr Error/is_raised_on_incorrect_authentication_details.yaml
-     * @test
-     */
+    /** @test */
     public function isRaisedOnIncorrectAuthenticationDetails()
     {
+        VCR::insertCassette('Error/is_raised_on_incorrect_authentication_details.yaml');
 
         $this->setExpectedException(AuthenticationException::class);
 
@@ -173,12 +165,10 @@ EOT;
             ->login();
     }
 
-    /**
-     * @vcr Error/is_raised_when_a_resource_is_not_found.yaml
-     * @test
-     */
+    /** @test */
     public function isRaisedWhenAResourceIsNotFound()
     {
+        VCR::insertCassette('Error/is_raised_when_a_resource_is_not_found.yaml');
 
         $this->setExpectedException(NotFoundException::class);
 
@@ -187,12 +177,10 @@ EOT;
             ->retrieve('081596c9-02de-483e-9f2a-4cf55dcdf98c');
     }
 
-    /**
-     * @vcr Error/is_raised_when_too_many_requests_have_been_issued.yaml
-     * @test
-     */
+    /** @test */
     public function isRaisedWhenToManyRequestsHaveBeenIssued()
     {
+        VCR::insertCassette('Error/is_raised_when_too_many_requests_have_been_issued.yaml');
 
         $this->setExpectedException(ToManyRequestsException::class);
 

--- a/tests/VCR/Ibans/Test.php
+++ b/tests/VCR/Ibans/Test.php
@@ -4,14 +4,15 @@ namespace CurrencyCloud\Tests\VCR\Ibans;
 use CurrencyCloud\Criteria\FindIbansCriteria;
 use CurrencyCloud\Model\Pagination;
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase {
 
-    /**
-     * @vcr Ibans/can_find_ibans.yaml
-     * @test
-     */
-    public function canFindIbans(){
+    /** @test */
+    public function canFindIbans()
+    {
+        VCR::insertCassette('Ibans/can_find_ibans.yaml');
+
         $findIbansCriteria = new FindIbansCriteria();
         $pagination = new Pagination();
         $ibans = $this->getAuthenticatedClient()->ibans()->find($findIbansCriteria, $pagination);

--- a/tests/VCR/Payers/Test.php
+++ b/tests/VCR/Payers/Test.php
@@ -3,14 +3,15 @@ namespace CurrencyCloud\Tests\VCR\Payers;
 
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
 use DateTime;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase {
 
-    /**
-     * @vcr Payers/can_get_payers.yaml
-     * @test
-     */
-    public function canGetPayer(){
+    /** @test */
+    public function canGetPayer()
+    {
+        VCR::insertCassette('Payers/can_get_payers.yaml');
+
         $payer = $this->getAuthenticatedClient()->payers()->retrieve("fa0b6125-6f81-4fc1-8861-544d7d5c9cdf");
         $this->assertSame("fa0b6125-6f81-4fc1-8861-544d7d5c9cdf",$payer->getId());
         $this->assertSame("individual",$payer->getLegalEntityType());

--- a/tests/VCR/Payments/Test.php
+++ b/tests/VCR/Payments/Test.php
@@ -2,14 +2,15 @@
 namespace CurrencyCloud\Tests\VCR\Payments;
 
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase {
 
-    /**
-     * @vcr Payments/can_authorise_payments.yaml
-     * @test
-     */
-    public function canAuthorisePayments(){
+    /** @test */
+    public function canAuthorisePayments()
+    {
+        VCR::insertCassette('Payments/can_authorise_payments.yaml');
+
         $authorisations = $this->getAuthenticatedClient()->payments()->authorise(
             [
                 '2416c8fe-0486-4fc3-82d9-4dc9a44eba9a',
@@ -34,11 +35,11 @@ class Test extends BaseCurrencyCloudVCRTestCase {
         }
     }
 
-    /**
-     * @vcr Payments/can_get_payment_submission.yaml
-     * @test
-     */
-    public function canGetPaymentSubmission(){
+    /** @test */
+    public function canGetPaymentSubmission()
+    {
+        VCR::insertCassette('Payments/can_get_payment_submission.yaml');
+
         $paymentSubmission = $this->getAuthenticatedClient()->payments()->retrieveSubmission('48e707c9-43e3-4b07-a1d1-bee38f9c95a1');
 
         $data = json_decode(
@@ -50,11 +51,11 @@ class Test extends BaseCurrencyCloudVCRTestCase {
         $this->assertSame($data['submission_ref'], $paymentSubmission->getSubmissionRef());
     }
 
-    /**
-     * @vcr Payments/can_get_payment_confirmation.yaml
-     * @test
-     */
-    public function canGetPaymentConfirmation(){
+    /** @test */
+    public function canGetPaymentConfirmation()
+    {
+        VCR::insertCassette('Payments/can_get_payment_confirmation.yaml');
+
         $paymentConfirmation = $this->getAuthenticatedClient()->payments()->retrieveConfirmation('796e0d7d-bae6-4d8a-b217-3cf9ee80a350');
 
         $dummy = json_decode(

--- a/tests/VCR/Rates/Test.php
+++ b/tests/VCR/Rates/Test.php
@@ -5,15 +5,14 @@ namespace CurrencyCloud\Tests\VCR\Rates;
 use CurrencyCloud\Model\DetailedRate;
 use CurrencyCloud\Model\Rates;
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase
 {
-    /**
-     * @vcr Rates/can_find.yaml
-     * @test
-     */
+    /** @test */
     public function canFind()
     {
+        VCR::insertCassette('Rates/can_find.yaml');
 
         $rates = $this->getAuthenticatedClient()->rates()->multiple(['GBPUSD', 'EURGBP']);
 
@@ -32,12 +31,10 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->assertEquals(count($dummy['unavailable']), count($rates->getUnavailable()));
     }
 
-    /**
-     * @vcr Rates/can_provided_detailed_rate.yaml
-     * @test
-     */
+    /** @test */
     public function canProvidedDetailedRate()
     {
+        VCR::insertCassette('Rates/can_provided_detailed_rate.yaml');
 
         $detailedRate = $this->getAuthenticatedClient()->rates()->detailed('GBP', 'USD', 'buy', 10000);
 
@@ -50,12 +47,10 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($detailedRate, $dummy);
     }
 
-    /**
-     * @vcr Rates/can_provided_detailed_rate_with_conversion_date_preference.yaml
-     * @test
-     */
+    /** @test */
     public function canProvidedDetailedRateWithConversionDatePreference()
     {
+        VCR::insertCassette('Rates/can_provided_detailed_rate_with_conversion_date_preference.yaml');
 
         $detailedRate = $this->getAuthenticatedClient()->rates()->detailed('GBP', 'USD',
             'buy', 10000, null, null, "conversion_date_preference");

--- a/tests/VCR/Reference/Test.php
+++ b/tests/VCR/Reference/Test.php
@@ -4,15 +4,14 @@ namespace CurrencyCloud\Tests\VCR\Reference;
 
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
 use DateTime;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase
 {
-    /**
-     * @vcr Reference/can_retrieve_beneficiary_required_details.yaml
-     * @test
-     */
+    /** @test */
     public function canRetrieveBeneficiaryRequiredDetails()
     {
+        VCR::insertCassette('Reference/can_retrieve_beneficiary_required_details.yaml');
 
         $requiredDetails = $this->getAuthenticatedClient()->reference()->beneficiaryRequiredDetails('GBP', 'GB', 'GB');
 
@@ -26,12 +25,10 @@ class Test extends BaseCurrencyCloudVCRTestCase
         }
     }
 
-    /**
-     * @vcr Reference/can_retrieve_conversion_dates.yaml
-     * @test
-     */
+    /** @test */
     public function canRetrieveConversionDates()
     {
+        VCR::insertCassette('Reference/can_retrieve_conversion_dates.yaml');
 
         $conversionDates = $this->getAuthenticatedClient()->reference()->conversionDates('GBPUSD');
 
@@ -304,12 +301,10 @@ class Test extends BaseCurrencyCloudVCRTestCase
         }
     }
 
-    /**
-     * @vcr Reference/can_retrieve_currencies.yaml
-     * @test
-     */
+    /** @test */
     public function canRetrieveCurrencies()
     {
+        VCR::insertCassette('Reference/can_retrieve_currencies.yaml');
 
         $currencies = $this->getAuthenticatedClient()->reference()->availableCurrencies();
 
@@ -330,12 +325,10 @@ class Test extends BaseCurrencyCloudVCRTestCase
         }
     }
 
-    /**
-     * @vcr Reference/can_retrieve_settlement_accounts.yaml
-     * @test
-     */
+    /** @test */
     public function canRetrieveSettlementAccounts()
     {
+        VCR::insertCassette('Reference/can_retrieve_settlement_accounts.yaml');
 
         $settlementAccounts = $this->getAuthenticatedClient()->reference()->settlementAccounts('GBP');
 
@@ -351,12 +344,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         }
     }
 
-    /**
-     * @vcr Reference/can_get_payer_required_details.yaml
-     * @test
-     */
+    /** @test */
     public function canGetPayerRequiredDetails()
     {
+        VCR::insertCassette('Reference/can_get_payer_required_details.yaml');
+
         $dummy = json_decode(
             '{"details":[{"payer_entity_type":"company","payment_type":"priority","required_fields":[{"name":"payer_country","validation_rule":"^[A-z]{2}$"},{"name":"payer_city","validation_rule":"^.{1,255}"},{"name":"payer_address","validation_rule":"^.{1,255}"},{"name":"payer_company_name","validation_rule":"^.{1,255}"},{"name":"payer_identification_value","validation_rule":"^.{1,255}"}],"payer_identification_type":"incorporation_number"},{"payer_entity_type":"individual","payment_type":"priority","required_fields":[{"name":"payer_country","validation_rule":"^[A-z]{2}$"},{"name":"payer_city","validation_rule":"^.{1,255}"},{"name":"payer_address","validation_rule":"^.{1,255}"},{"name":"payer_first_name","validation_rule":"^.{1,255}"},{"name":"payer_last_name","validation_rule":"^.{1,255}"},{"name":"payer_date_of_birth","validation_rule":"/A([+-]?d{4}(?!d{2}\b))((-?)((0[1-9]|1[0-2])(\u0003([12]d|0[1-9]|3[01]))?|W([0-4]d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]d|[12]d{2}|3([0-5]d|6[1-6])))([T ]((([01]d|2[0-3])((:?)[0-5]d)?|24:?00)([.,]d+(?!:))?)?(\u000f[0-5]d([.,]d+)?)?([zZ]|([+-])([01]d|2[0-3]):?([0-5]d)?)?)?)?Z/"}]},{"payer_entity_type":"company","payment_type":"regular","required_fields":[{"name":"payer_country","validation_rule":"^[A-z]{2}$"},{"name":"payer_city","validation_rule":"^.{1,255}"},{"name":"payer_address","validation_rule":"^.{1,255}"},{"name":"payer_company_name","validation_rule":"^.{1,255}"}]},{"payer_entity_type":"individual","payment_type":"regular","required_fields":[{"name":"payer_country","validation_rule":"^[A-z]{2}$"},{"name":"payer_city","validation_rule":"^.{1,255}"},{"name":"payer_address","validation_rule":"^.{1,255}"},{"name":"payer_first_name","validation_rule":"^.{1,255}"},{"name":"payer_last_name","validation_rule":"^.{1,255}"},{"name":"payer_date_of_birth","validation_rule":"/A([+-]?d{4}(?!d{2}\b))((-?)((0[1-9]|1[0-2])(\u0003([12]d|0[1-9]|3[01]))?|W([0-4]d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]d|[12]d{2}|3([0-5]d|6[1-6])))([T ]((([01]d|2[0-3])((:?)[0-5]d)?|24:?00)([.,]d+(?!:))?)?(\u000f[0-5]d([.,]d+)?)?([zZ]|([+-])([01]d|2[0-3]):?([0-5]d)?)?)?)?Z/"}]}]        }',
             true

--- a/tests/VCR/Reports/Test.php
+++ b/tests/VCR/Reports/Test.php
@@ -6,16 +6,15 @@ use CurrencyCloud\Model\Pagination;
 use CurrencyCloud\Model\Report;
 use CurrencyCloud\Criteria\ConversionReportCriteria;
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
 
 class Test extends BaseCurrencyCloudVCRTestCase{
 
-    /**
-     * @vcr Reports/can_create_conversion_report.yaml
-     * @test
-     */
+    /** @test */
     public function canCreateConversionReport()
     {
+        VCR::insertCassette('Reports/can_create_conversion_report.yaml');
 
         $conversionReportCriteria = new ConversionReportCriteria();
         $conversionReportCriteria->setBuyCurrency("EUR")
@@ -33,12 +32,10 @@ class Test extends BaseCurrencyCloudVCRTestCase{
         $this->assertSame($dummy['short_reference'], $report->getShortReference());
     }
 
-    /**
-     * @vcr Reports/can_create_payment_report.yaml
-     * @test
-     */
+    /** @test */
     public function canCreatePaymentReport()
     {
+        VCR::insertCassette('Reports/can_create_payment_report.yaml');
 
         $paymentReportCriteria = new PaymentReportCriteria();
         $paymentReportCriteria->setCurrency("EUR");
@@ -55,12 +52,10 @@ class Test extends BaseCurrencyCloudVCRTestCase{
         $this->assertSame($dummy['short_reference'], $report->getShortReference());
     }
 
-    /**
-     * @vcr Reports/can_find_reports_requests.yaml
-     * @test
-     */
+    /** @test */
     public function canFindReportsRequests()
     {
+        VCR::insertCassette('Reports/can_find_reports_requests.yaml');
 
         $findReportsCriteria = new FindReportsCriteria();
         $pagination = new Pagination();
@@ -83,15 +78,13 @@ class Test extends BaseCurrencyCloudVCRTestCase{
         $this->assertSame($dummy['report_requests'][0]['search_params']['buy_currency'], $reports->getReports()[0]->getSearchParams()->getBuyCurrency());
         $this->assertSame($dummy['report_requests'][0]['search_params']['sell_currency'], $reports->getReports()[0]->getSearchParams()->getSellCurrency());
         $this->assertSame($dummy['report_requests'][0]['search_params']['scope'], $reports->getReports()[0]->getSearchParams()->getScope());
-
     }
 
-    /**
-     * @vcr Reports/can_retrieve_report.yaml
-     * @test
-     */
+    /** @test */
     public function canRetrieveReport()
     {
+        VCR::insertCassette('Reports/can_retrieve_report.yaml');
+
         $report = $this->getAuthenticatedClient()->reports()->retrieve("075ce584-b977-4538-a524-16b759277d66");
 
         $dummy = json_decode(
@@ -101,6 +94,5 @@ class Test extends BaseCurrencyCloudVCRTestCase{
 
         $this->assertSame($dummy['id'], $report->getId());
         $this->assertSame($dummy['short_reference'], $report->getShortReference());
-
     }
 }

--- a/tests/VCR/Transactions/Test.php
+++ b/tests/VCR/Transactions/Test.php
@@ -2,13 +2,15 @@
 namespace CurrencyCloud\Model;
 
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
-class Test extends BaseCurrencyCloudVCRTestCase {
-    /**
-     * @vcr Transactions/can_retrieve_sender_details.yaml
-     * @test
-     */
-    public function canRetrieveSenderDetails(){
+class Test extends BaseCurrencyCloudVCRTestCase
+{
+    /** @test */
+    public function canRetrieveSenderDetails()
+    {
+        VCR::insertCassette('Transactions/can_retrieve_sender_details.yaml');
+
         $senderDetails = $this->getAuthenticatedClient()->transactions()->retrieveSender('');
 
         $dummy = json_decode(

--- a/tests/VCR/Transfers/Test.php
+++ b/tests/VCR/Transfers/Test.php
@@ -4,14 +4,15 @@ namespace CurrencyCloud\Tests\VCR\Transfers;
 use CurrencyCloud\Criteria\FindTransferCriteria;
 use CurrencyCloud\Model\Pagination;
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase {
 
-    /**
-     * @vcr Transfers/can_get_transfer.yaml
-     * @test
-     */
-    public function canGetTransfer(){
+    /** @test */
+    public function canGetTransfer()
+    {
+        VCR::insertCassette('Transfers/can_get_transfer.yaml');
+
         $transfer = $this->getAuthenticatedClient()->transfers()->retrieve('dbc1b2c3-fc83-439a-8ce9-5cdfc2cb321a');
 
         $dummy = json_decode(
@@ -29,11 +30,11 @@ class Test extends BaseCurrencyCloudVCRTestCase {
         $this->assertSame($dummy['unique_request_id'], $transfer->getUniqueRequestId());
     }
 
-    /**
-     * @vcr Transfers/can_find_transfers.yaml
-     * @test
-     */
-    public function canFindTransfers(){
+    /** @test */
+    public function canFindTransfers()
+    {
+        VCR::insertCassette('Transfers/can_find_transfers.yaml');
+
         $findTransfersCriteria = new FindTransferCriteria();
         $pagination = new Pagination();
 
@@ -58,11 +59,10 @@ class Test extends BaseCurrencyCloudVCRTestCase {
         }
     }
 
-    /**
-     * @vcr Transfers/can_create_transfer.yaml
-     * @test
-     */
-    public function canCreateTransfer(){
+    /** @test */
+    public function canCreateTransfer()
+    {
+        VCR::insertCassette('Transfers/can_create_transfer.yaml');
 
         $transfers = $this->getAuthenticatedClient()->transfers()->create(
             'cf28b2d8-5afa-4d7f-9a26-7b45bf616a11',

--- a/tests/VCR/Update/Test.php
+++ b/tests/VCR/Update/Test.php
@@ -3,15 +3,15 @@
 namespace CurrencyCloud\Tests\VCR\Update;
 
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase
 {
-    /**
-     * @vcr Update/does_nothing_if_nothing_has_changed.yaml
-     * @test
-     */
+    /** @test */
     public function doesNothingIfNothingHasChanged()
     {
+        VCR::insertCassette('Update/does_nothing_if_nothing_has_changed.yaml');
+
         $client = $this->getAuthenticatedClient();
 
         $beneficiary =
@@ -29,12 +29,11 @@ class Test extends BaseCurrencyCloudVCRTestCase
         $this->validateObjectStrictName($beneficiary, $dummy);
     }
 
-    /**
-     * @vcr Update/only_updates_changed_records.yaml
-     * @test
-     */
+    /** @test */
     public function onlyUpdatesChangedRecords()
     {
+        VCR::insertCassette('Update/only_updates_changed_records.yaml');
+
         $client = $this->getAuthenticatedClient();
 
         $beneficiary =

--- a/tests/VCR/Vans/Test.php
+++ b/tests/VCR/Vans/Test.php
@@ -3,14 +3,14 @@ namespace CurrencyCloud\Tests\VCR\Vans;
 
 use CurrencyCloud\Model\Pagination;
 use CurrencyCloud\Tests\BaseCurrencyCloudVCRTestCase;
+use VCR\VCR;
 
 class Test extends BaseCurrencyCloudVCRTestCase {
 
-    /**
-     * @vcr Vans/can_get_vans.yaml
-     * @test
-     */
-    public function canGetVans(){
+    /** @test */
+    public function canGetVans()
+    {
+        VCR::insertCassette('Vans/can_get_vans.yaml');
 
         $pagination = new Pagination();
         $vansCollection = $this->getAuthenticatedClient()->vans()->retrieveVans($pagination);
@@ -31,11 +31,10 @@ class Test extends BaseCurrencyCloudVCRTestCase {
         $this->assertSame($dummy['virtual_accounts'][0]['routing_code'], $vansCollection->getVans()[0]->getRoutingCode());
     }
 
-    /**
-     * @vcr Vans/can_find_vans.yaml
-     * @test
-     */
-    public function canFindVans(){
+    /** @test */
+    public function canFindVans()
+    {
+        VCR::insertCassette('Vans/can_find_vans.yaml');
 
         $pagination = new Pagination();
         $vansCollection = $this->getAuthenticatedClient()->vans()->find($pagination);


### PR DESCRIPTION
This PR adds support for Symfony 6. As Symfony 6 requires PHP 8 the package is now compatible with PHP 8 too. 

I had to drop the `php-vcr/phpunit-testlistener-vcr` dependency as that package seems no longer maintained. Instead I've refactored the tests to set the VCR cassette from within the test itself.
