### PR TITLE
Fix incorrectly mapped transaction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "require": {
     "php": ">=7.2",
+    "ext-json": "*",
     "guzzlehttp/guzzle": "~6.1||~7.0",
     "symfony/yaml": "^2.7||^3.0||^4.0||^5.0||^6.0",
     "symfony/event-dispatcher": "^5.0||^6.0"

--- a/src/EntryPoint/TransactionsEntryPoint.php
+++ b/src/EntryPoint/TransactionsEntryPoint.php
@@ -138,7 +138,7 @@ class TransactionsEntryPoint extends AbstractEntryPoint
             ->setReason($response->reason)
             ->setSettlesAt((null === $response->settles_at) ? null : new DateTime($response->settles_at))
             ->setCreatedAt((null === $response->created_at) ? null : new DateTime($response->created_at))
-            ->setCompletedAt((null === $response->created_at) ? null : new DateTime($response->created_at))
+            ->setCompletedAt((null === $response->completed_at) ? null : new DateTime($response->completed_at))
             ->setUpdatedAt((null === $response->updated_at) ? null : new DateTime($response->updated_at));
 
         $this->setIdProperty($transaction, $response->id);

--- a/tests/EntryPoint/TransactionsEntryPointTest.php
+++ b/tests/EntryPoint/TransactionsEntryPointTest.php
@@ -18,7 +18,7 @@ class TransactionsEntryPointTest extends BaseCurrencyCloudTestCase
      */
     public function canRetrieve()
     {
-        $data = '{"id":"c5a990eb-d4d7-482f-bfb1-695261fb1e4d","balance_id":"c5f1f54e-d6d8-4140-8110-f5b99bbc80c3","account_id":"7b9757a8-eee9-4572-86e6-77f4d711eaa6","currency":"USD","amount":"1000.00","balance_amount":"2000.00","type":"credit","action":"conversion","related_entity_type":"conversion","related_entity_id":"ConversionUUID","related_entity_short_reference":"140416-GGJBNQ001","status":"completed","reason":"Reason for Transaction","settles_at":"2014-01-12T12:24:19+00:00","created_at":"2014-01-12T12:24:19+00:00","updated_at":"2014-01-12T12:24:19+00:00","completed_at":"2014-01-12T12:24:19+00:00"}';
+        $data = '{"id":"c5a990eb-d4d7-482f-bfb1-695261fb1e4d","balance_id":"c5f1f54e-d6d8-4140-8110-f5b99bbc80c3","account_id":"7b9757a8-eee9-4572-86e6-77f4d711eaa6","currency":"USD","amount":"1000.00","balance_amount":"2000.00","type":"credit","action":"conversion","related_entity_type":"conversion","related_entity_id":"ConversionUUID","related_entity_short_reference":"140416-GGJBNQ001","status":"completed","reason":"Reason for Transaction","settles_at":"2014-01-12T12:24:20+00:00","created_at":"2014-01-12T12:24:19+00:00","updated_at":"2015-03-02T07:53:46+00:00","completed_at":"2014-01-12T12:24:21+00:00"}';
 
         $entryPoint = new TransactionsEntryPoint(
             $this->getMockedClient(


### PR DESCRIPTION
Fix an issue where `TransactionsEntryPoint::retrieve()` return an incorrectly mapped `Transaction` object. In particular the `Transaction::$completedAt` was assigned with incorrect value.