### PR TITLE
Fix missing on_behalf_of in find beneficiaries

### DIFF
--- a/src/EntryPoint/BeneficiariesEntryPoint.php
+++ b/src/EntryPoint/BeneficiariesEntryPoint.php
@@ -25,8 +25,8 @@ class BeneficiariesEntryPoint extends AbstractEntityEntryPoint
             [],
             $this->convertBeneficiaryToRequest(
                 $beneficiary,
+                $onBehalfOf,
                 true,
-                $onBehalfOf
             )
         );
         return $this->createBeneficiaryFromResponse($response, true);
@@ -127,8 +127,12 @@ class BeneficiariesEntryPoint extends AbstractEntityEntryPoint
      *
      * @return array
      */
-    protected function convertBeneficiaryToRequest(Beneficiary $beneficiary, $convertForValidate = false, $convertForUpdate = false)
-	{
+    protected function convertBeneficiaryToRequest(
+        Beneficiary $beneficiary,
+        $onBehalfOf = null,
+        $convertForValidate = false,
+        $convertForUpdate = false
+    ) {
         $isDefaultBeneficiary = $beneficiary->isDefaultBeneficiary();
         $common = [
             'bank_country' => $beneficiary->getBankCountry(),
@@ -161,6 +165,9 @@ class BeneficiariesEntryPoint extends AbstractEntityEntryPoint
             'beneficiary_identification_value' => $beneficiary->getBeneficiaryIdentificationValue(),
             'payment_types' => $beneficiary->getPaymentTypes()
         ];
+        if ($onBehalfOf) {
+            $common['on_behalf_of'] = $onBehalfOf;
+        }
 
         if ($convertForValidate) {
             return $common;


### PR DESCRIPTION
Currently the `->beneficiaries()->find()` call does not correctly apply the `onBehalfOf` argument to the HTTP request. This PR fixes this bug while maintaining all other existing behaviour.

This bug was previously addressed in another PR which is still open and looks like was never reviewed https://github.com/CurrencyCloud/currencycloud-php/pull/116.

However the other PR now requires rebasing, and the member of our team who raised it no longer works at our company, therefore raising this one in favour of it. This also makes fewer, more targeted changes so hopefully easier to review.

Thank you!