### PR TITLE
WAL-3164: Mark as deprecated the "reason" as filter for transactions/find

### DIFF
--- a/src/EntryPoint/TransactionsEntryPoint.php
+++ b/src/EntryPoint/TransactionsEntryPoint.php
@@ -113,7 +113,7 @@ class TransactionsEntryPoint extends AbstractEntryPoint
             'related_entity_short_reference' => $transaction->getRelatedEntityShortReference(),
             'status' => $transaction->getStatus(),
             'type' => $transaction->getType(),
-            'reason' => $transaction->getReason()
+            'reason' => $transaction->getReason() // Deprecated
         ];
     }
 

--- a/tests/EntryPoint/TransactionsEntryPointTest.php
+++ b/tests/EntryPoint/TransactionsEntryPointTest.php
@@ -84,7 +84,7 @@ class TransactionsEntryPointTest extends BaseCurrencyCloudTestCase
                 'related_entity_short_reference' => null,
                 'status' => null,
                 'type' => null,
-                'reason' => null,
+                'reason' => null, // Deprecated
                 'on_behalf_of' => null,
                 'amount_from' => null,
                 'amount_to' => null,
@@ -149,7 +149,7 @@ class TransactionsEntryPointTest extends BaseCurrencyCloudTestCase
                 'related_entity_short_reference' => 'H',
                 'status' => 'I',
                 'type' => 'J',
-                'reason' => 'K',
+                'reason' => 'K', // Deprecated
                 'on_behalf_of' => 'L',
                 'amount_from' => 'A',
                 'amount_to' => 'B',


### PR DESCRIPTION
Initiate removal of the filter.